### PR TITLE
Added support for B450M Bazooka Plus and fixed reversed lights issue

### DIFF
--- a/MSIRGB.DLL/logic/Lighting.cpp
+++ b/MSIRGB.DLL/logic/Lighting.cpp
@@ -137,11 +137,11 @@ namespace logic {
             return false;
         }
 
-		if (reverse_colours) {
-			colour.r = 0x0F - colour.r;
-			colour.g = 0x0F - colour.g;
-			colour.b = 0x0F - colour.b;
-		}
+        if (reverse_colours) {
+            colour.r = 0x0F - colour.r;
+            colour.g = 0x0F - colour.g;
+            colour.b = 0x0F - colour.b;
+        }
 
         curr_batch.colours.insert_or_assign(index, colour);
 
@@ -173,11 +173,11 @@ namespace logic {
         std::uint8_t r = (r_cell >> (!nibble_pos * 4)) & 0x0F;
         std::uint8_t g = (g_cell >> (!nibble_pos * 4)) & 0x0F;
         std::uint8_t b = (b_cell >> (!nibble_pos * 4)) & 0x0F;
-		if (reverse_colours) {
-			r = 0x0F - r;
-			g = 0x0F - g;
-			b = 0x0F - b;
-		}
+        if (reverse_colours) {
+            r = 0x0F - r;
+            g = 0x0F - g;
+            b = 0x0F - b;
+        }
 
         return std::make_optional(Colour{ r, g, b });
     }
@@ -298,12 +298,12 @@ namespace logic {
             L"7B40",
             L"7A94",
             L"7B09",
-			L"7B90"
+            L"7B90"
         };
 
-		static const std::list<std::wstring> reversed_mbs = { // colours are reversed on these.
-			L"7B90"
-		};
+        static const std::list<std::wstring> reversed_mbs = { // colours are reversed on these.
+            L"7B90"
+        };
 
         auto found = std::find_if(supported_mbs.begin(),
             supported_mbs.end(),
@@ -327,16 +327,16 @@ namespace logic {
             return MbCompatError::UnsupportedModel;
         }
         else {
-			auto rev_found = std::find_if(reversed_mbs.begin(),
-				reversed_mbs.end(),
-				[&info](const std::wstring & mb_model) -> bool {
-					return info[L"Product"].find(mb_model) != std::wstring::npos;
-			});
-			Lighting::reverse_colours = rev_found != reversed_mbs.end();
+            auto rev_found = std::find_if(reversed_mbs.begin(),
+                reversed_mbs.end(),
+                [&info](const std::wstring & mb_model) -> bool {
+                    return info[L"Product"].find(mb_model) != std::wstring::npos;
+            });
+            Lighting::reverse_colours = rev_found != reversed_mbs.end();
             return MbCompatError::Ok;
         }
     }
-	bool Lighting::reverse_colours = false;
+    bool Lighting::reverse_colours = false;
 
     void Lighting::batch_commit()
     {

--- a/MSIRGB.DLL/logic/Lighting.cpp
+++ b/MSIRGB.DLL/logic/Lighting.cpp
@@ -137,6 +137,12 @@ namespace logic {
             return false;
         }
 
+		if (reverse_colours) {
+			colour.r = 0x0F - colour.r;
+			colour.g = 0x0F - colour.g;
+			colour.b = 0x0F - colour.b;
+		}
+
         curr_batch.colours.insert_or_assign(index, colour);
 
         if (!batch_calls) {
@@ -167,6 +173,11 @@ namespace logic {
         std::uint8_t r = (r_cell >> (!nibble_pos * 4)) & 0x0F;
         std::uint8_t g = (g_cell >> (!nibble_pos * 4)) & 0x0F;
         std::uint8_t b = (b_cell >> (!nibble_pos * 4)) & 0x0F;
+		if (reverse_colours) {
+			r = 0x0F - r;
+			g = 0x0F - g;
+			b = 0x0F - b;
+		}
 
         return std::make_optional(Colour{ r, g, b });
     }
@@ -286,8 +297,13 @@ namespace logic {
             L"7A68",
             L"7B40",
             L"7A94",
-            L"7B09"
+            L"7B09",
+			L"7B90"
         };
+
+		static const std::list<std::wstring> reversed_mbs = { // colours are reversed on these.
+			L"7B90"
+		};
 
         auto found = std::find_if(supported_mbs.begin(),
             supported_mbs.end(),
@@ -311,9 +327,16 @@ namespace logic {
             return MbCompatError::UnsupportedModel;
         }
         else {
+			auto rev_found = std::find_if(reversed_mbs.begin(),
+				reversed_mbs.end(),
+				[&info](const std::wstring & mb_model) -> bool {
+					return info[L"Product"].find(mb_model) != std::wstring::npos;
+			});
+			Lighting::reverse_colours = rev_found != reversed_mbs.end();
             return MbCompatError::Ok;
         }
     }
+	bool Lighting::reverse_colours = false;
 
     void Lighting::batch_commit()
     {

--- a/MSIRGB.DLL/logic/Lighting.h
+++ b/MSIRGB.DLL/logic/Lighting.h
@@ -77,6 +77,7 @@ namespace logic {
         };
 
         static MbCompatError    check_supported_mb();
+		static bool             reverse_colours;  // On some motherboards, the colours are reversed.
 
         void                    batch_commit();
 

--- a/MSIRGB.DLL/logic/Lighting.h
+++ b/MSIRGB.DLL/logic/Lighting.h
@@ -77,7 +77,7 @@ namespace logic {
         };
 
         static MbCompatError    check_supported_mb();
-		static bool             reverse_colours;  // On some motherboards, the colours are reversed.
+        static bool             reverse_colours;  // On some motherboards, the colours are reversed.
 
         void                    batch_commit();
 

--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ Learn more about how to create scripts and find the Lua API reference in the [wi
  - MSI A320M GRENADE
  - MSI B450M PRO-VDH
  - MSI B450M BAZOOKA
+ - MSI B450M BAZOOKA PLUS
  - MSI X470 GAMING PRO CARBON AC
  - MSI X470 GAMING M7 AC
  - MSI X470 GAMING PLUS
@@ -80,6 +81,7 @@ Learn more about how to create scripts and find the Lua API reference in the [wi
 # Reported working motherboards
  - MSI B450I GAMING PLUS AC
  - MSI Z270 GAMING M7
+ - MSI B450M BAZOOKA PLUS
  
  **Certain motherboards are not supported by MSI Mystic Light and so are not on the list in section [Motherboard support](#motherboard-support) but some of them have been reported to be working with MSIRGB all the same. They are the following:**
  - MSI B350 TOMAHAWK


### PR DESCRIPTION
Fixes #39 . Support for #37 can be added by adding the motherboard version to the list of `reversed_mbs`.