### PR TITLE
fixed issue #39, add b450m mortar to supported devices

### DIFF
--- a/MSIRGB.DLL/logic/Lighting.cpp
+++ b/MSIRGB.DLL/logic/Lighting.cpp
@@ -286,7 +286,8 @@ namespace logic {
             L"7A68",
             L"7B40",
             L"7A94",
-            L"7B09"
+            L"7B09",
+            L"7B89"
         };
 
         auto found = std::find_if(supported_mbs.begin(),
@@ -357,8 +358,8 @@ namespace logic {
             // Also make sure some 'weird' fade in behaviour that happens in some boards is disabled
 
             // Invert value is second group of 3 bits from the left in 0xFF: BGR, in this order, from leftmost bit to rightmost bit
-            // If bit is set, channel is inverted
-            val_at_ff &= 0b11100011;
+            // Depending on MB, channel is inverted either if bit is set or not; this may have to do with the LED controller used
+            // val_at_ff &= 0b11100011;
 
             // Fade in value is first 3 bits: BGR, in this order, from leftmost bit to rightmost bit
             // If bit is set, fade in is disabled

--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ Learn more about how to create scripts and find the Lua API reference in the [wi
  - MSI A320M GRENADE
  - MSI B450M PRO-VDH
  - MSI B450M BAZOOKA
+ - MSI B450M MORTAR
  - MSI X470 GAMING PRO CARBON AC
  - MSI X470 GAMING M7 AC
  - MSI X470 GAMING PLUS


### PR DESCRIPTION
This should fix the issue where the RGB channels are reversed. If an older version of this tool was used before and the issue is currently present, launching MysticLight once and setting a color resolved it for me. Using a build with this fix then prevented it from happening again.

I believe the issue occurs because of different LED controllers used in different motherboards. The original version of the tool was written for the NCT6795 chip, wasn't it? The B450M Mortar uses the NCT6797. Perhaps in the newer modell the meaning of the three bits in question is reversed?

The linux utility https://github.com/nagisa/msi-rgb reflects these ideas as well. A check for the LED controller itself is implemented: Valid IDs are 0xD350 (NCT6795 according to a comment in the code) and 0xD450 (NCT6797, which I can confirm).

I could implement something similar for this tool, though I'm not sure if that would be necessary or even beneficial. For me, launching MysticLight fixed the issue (and set the bits properly), so just not overwriting them should suffice.